### PR TITLE
[Feat/#5]: 이메일 & 비밀번호 폼 구현

### DIFF
--- a/src/app/(DefaultLayout)/landing/page.tsx
+++ b/src/app/(DefaultLayout)/landing/page.tsx
@@ -20,7 +20,7 @@ function LandingPage() {
           <br />
           나갈 시간
         </h2>
-        <ButtonWithText btnText='로그인 하기'>
+        <ButtonWithText btnText='로그인 하기' route='/login'>
           <div className='flex gap-[6px]'>
             <span className='text-body_lg text-gray-400'>우리 초면인가요?</span>
             <Link href='/join?step=1' className='text-body_lg_bold text-white'>

--- a/src/app/(FormLayout)/join/page.tsx
+++ b/src/app/(FormLayout)/join/page.tsx
@@ -11,7 +11,11 @@ function JoinPage() {
   const step = Number(useSearchParams().get('step')!);
 
   const methods = useForm<IJoinForm>({
+    mode: 'onBlur',
     defaultValues: {
+      email: '',
+      password: '',
+      passwordCheck: '',
       terms: {
         marketing: false,
         ads: false,

--- a/src/app/(FormLayout)/join/page.tsx
+++ b/src/app/(FormLayout)/join/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Step1 from '@/components/join/step1/Step1';
+import Step2 from '@/components/join/step2/Step2';
 import { IJoinForm } from '@/types/form';
 import { useSearchParams } from 'next/navigation';
 import React from 'react';
@@ -20,7 +21,10 @@ function JoinPage() {
 
   return (
     <FormProvider {...methods}>
-      <form className='h-full'>{step === 1 && <Step1 />}</form>
+      <form className='h-full'>
+        {step === 1 && <Step1 />}
+        {step === 2 && <Step2 />}
+      </form>
     </FormProvider>
   );
 }

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -2,15 +2,22 @@ import React from 'react';
 
 interface Props {
   children: React.ReactNode;
+  onClick: () => void;
   type?: 'button' | 'submit';
   disabled?: boolean;
 }
 
-function Button({ children, type = 'button', disabled = false }: Props) {
+function Button({
+  children,
+  type = 'button',
+  onClick,
+  disabled = false,
+}: Props) {
   return (
     <button
       type={type}
       disabled={disabled}
+      onClick={onClick}
       className={`bg-main text-body_lg_bold box-border w-full rounded-[30px] px-[30px] py-[18px] text-white transition-all`}
     >
       {children}

--- a/src/components/common/button/ButtonWithText.tsx
+++ b/src/components/common/button/ButtonWithText.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
-import Button from './Button';
+import LinkButton from './LinkButton';
 
 interface Props {
   btnText: string;
   children: React.ReactNode;
+  route: string;
 }
 
-function ButtonWithText({ children, btnText }: Props) {
+function ButtonWithText({ children, btnText, route }: Props) {
   return (
     <div className='flex h-[120px] flex-col'>
-      <Button>{btnText}</Button>
+      <LinkButton route={route}>{btnText}</LinkButton>
       <div className='flex w-full flex-1 items-center justify-center'>
         {children}
       </div>

--- a/src/components/common/button/LinkButton.tsx
+++ b/src/components/common/button/LinkButton.tsx
@@ -4,13 +4,14 @@ import React from 'react';
 interface Props {
   children: React.ReactNode;
   route: string;
+  disabled?: boolean;
 }
 
-function LinkButton({ children, route }: Props) {
+function LinkButton({ children, route, disabled }: Props) {
   return (
     <Link
       href={route}
-      className={`bg-main text-body_lg_bold box-border w-full rounded-[30px] px-[30px] py-[18px] text-center text-white transition-all`}
+      className={`bg-main text-body_lg_bold box-border w-full rounded-[30px] px-[30px] py-[18px] text-center text-white transition-all ${disabled ? `pointer-events-none opacity-[0.4]` : ``}`}
     >
       {children}
     </Link>

--- a/src/components/common/button/LinkButton.tsx
+++ b/src/components/common/button/LinkButton.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import React from 'react';
+
+interface Props {
+  children: React.ReactNode;
+  route: string;
+}
+
+function LinkButton({ children, route }: Props) {
+  return (
+    <Link
+      href={route}
+      className={`bg-main text-body_lg_bold box-border w-full rounded-[30px] px-[30px] py-[18px] text-center text-white transition-all`}
+    >
+      {children}
+    </Link>
+  );
+}
+
+export default LinkButton;

--- a/src/components/common/form/FormButton.tsx
+++ b/src/components/common/form/FormButton.tsx
@@ -1,9 +1,10 @@
+import Link from 'next/link';
 import React from 'react';
 
 const mode = {
   div: {
     default: `px-[24px]`,
-    typing: `px-0`,
+    typing: `px-0 sticky`,
   },
   button: {
     default: `rounded-[30px]`,
@@ -11,14 +12,23 @@ const mode = {
   },
 };
 
-function FormButton() {
+interface Props {
+  route: string;
+  isTyping: boolean;
+  disabled?: boolean;
+}
+
+function FormButton({ route, isTyping, disabled }: Props) {
   return (
-    <div className={`w-full ${mode.div.default} transition-all`}>
-      <button
-        className={`bg-main text-body_lg_bold box-border w-full px-[30px] py-[18px] ${mode.button.default} transition-all`}
+    <div
+      className={`w-full ${isTyping ? mode.div.typing : mode.div.default} flex transition-all`}
+    >
+      <Link
+        href={route}
+        className={`bg-main text-body_lg_bold box-border w-full px-[30px] py-[18px] text-center ${isTyping ? mode.button.typing : mode.button.default} transition-all ${disabled ? `pointer-events-none opacity-[0.4]` : ``}`}
       >
-        버튼
-      </button>
+        다음
+      </Link>
     </div>
   );
 }

--- a/src/components/common/form/FormInput.tsx
+++ b/src/components/common/form/FormInput.tsx
@@ -8,19 +8,20 @@ interface Props {
 }
 
 const inputStyle = {
-  default: 'border-gray-800 bg-gray-800 text-white placeholder:text-gray-600',
+  default:
+    'border-gray-800 bg-gray-800 text-white placeholder:text-gray-600 focus:border-main',
   error: 'border-error bg-error_bg text-white placeholder:text-white',
   pass: 'border-main bg-gray-800 text-white placeholder:text-gray-600',
 };
 
 function FormInput({ type, placeholder, title, errorMsg }: Props) {
   return (
-    <div className='flex flex-col'>
-      <h6 className='text-body_md text-white'>{title}</h6>
+    <div className='flex flex-col gap-[8px]'>
+      {title && <h6 className='text-body_md mb-[4px] text-white'>{title}</h6>}
       <input
         type={type}
         placeholder={placeholder}
-        className={`text-body_lg mb-[8px] mt-[12px] rounded-[12px] border px-[16px] py-[18px] outline-none ${inputStyle.error}`}
+        className={`text-body_lg rounded-[12px] border px-[16px] py-[18px] outline-none ${inputStyle.default}`}
       />
       <span className='text-body_md text-error'>{errorMsg}</span>
     </div>

--- a/src/components/common/form/FormInput.tsx
+++ b/src/components/common/form/FormInput.tsx
@@ -1,29 +1,47 @@
 import React from 'react';
+import { RegisterOptions, useFormContext } from 'react-hook-form';
 
 interface Props {
   type: 'text' | 'email' | 'password';
   placeholder: string;
   title?: string;
   errorMsg?: string;
+  fieldName: 'email' | 'password' | 'passwordCheck';
+  options: RegisterOptions;
 }
 
 const inputStyle = {
   default:
     'border-gray-800 bg-gray-800 text-white placeholder:text-gray-600 focus:border-main',
   error: 'border-error bg-error_bg text-white placeholder:text-white',
-  pass: 'border-main bg-gray-800 text-white placeholder:text-gray-600',
 };
 
-function FormInput({ type, placeholder, title, errorMsg }: Props) {
+function FormInput({
+  type,
+  placeholder,
+  title,
+  errorMsg,
+  fieldName,
+  options,
+}: Props) {
+  const {
+    register,
+    watch,
+    formState: { errors },
+  } = useFormContext();
+
   return (
     <div className='flex flex-col gap-[8px]'>
       {title && <h6 className='text-body_md mb-[4px] text-white'>{title}</h6>}
       <input
         type={type}
         placeholder={placeholder}
-        className={`text-body_lg rounded-[12px] border px-[16px] py-[18px] outline-none ${inputStyle.default}`}
+        className={`text-body_lg rounded-[12px] border px-[16px] py-[18px] outline-none ${watch(fieldName) && errors[fieldName] ? inputStyle.error : inputStyle.default}`}
+        {...register(fieldName, options)}
       />
-      <span className='text-body_md text-error'>{errorMsg}</span>
+      <span className='text-body_md text-error'>
+        {watch(fieldName) && errors[fieldName] && errors[fieldName]!.message}
+      </span>
     </div>
   );
 }

--- a/src/components/join/step1/CheckItem.tsx
+++ b/src/components/join/step1/CheckItem.tsx
@@ -19,7 +19,7 @@ function CheckItem({ termsData }: Props) {
   const isChecked = isIncluded ? true : watch(`terms.${termsData.name}`);
 
   return (
-    <div className='flex justify-between'>
+    <div className='flex justify-between gap-[20px]'>
       <div className='flex gap-[12px]'>
         <button
           type='button'
@@ -46,7 +46,7 @@ function CheckItem({ termsData }: Props) {
         <button
           type='button'
           onClick={() => setOpenDetail(true)}
-          className='text-body_md text-gray-600'
+          className='text-body_md w-[30px] text-end text-gray-600'
         >
           보기
         </button>

--- a/src/components/join/step1/Step1.tsx
+++ b/src/components/join/step1/Step1.tsx
@@ -11,7 +11,7 @@ function Step1() {
         <CheckAllItem />
         <TermsContainer />
       </div>
-      <ButtonWithText btnText='다음'>
+      <ButtonWithText btnText='다음' route='/join?step=2'>
         <p className='text-body_sm text-center text-gray-400'>
           개인정보 수집 및 이용에 대한 동의를 거부할 권리가 있으며,
           <br />

--- a/src/components/join/step2/Step2.tsx
+++ b/src/components/join/step2/Step2.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+function Step2() {
+  return (
+    <div className='p-page flex h-full flex-col justify-between'>Step2</div>
+  );
+}
+
+export default Step2;

--- a/src/components/join/step2/Step2.tsx
+++ b/src/components/join/step2/Step2.tsx
@@ -1,8 +1,27 @@
+import LinkButton from '@/components/common/button/LinkButton';
+import FormInput from '@/components/common/form/FormInput';
 import React from 'react';
 
 function Step2() {
   return (
-    <div className='p-page flex h-full flex-col justify-between'>Step2</div>
+    <div className='p-page flex h-full flex-col justify-between'>
+      <div className='flex flex-col gap-[36px]'>
+        <FormInput
+          type='email'
+          placeholder='이메일을 입력하세요'
+          title='이메일'
+        />
+        <div>
+          <FormInput
+            type='password'
+            placeholder='8~15자 영문 대소문자, 숫자 포함'
+            title='비밀번호'
+          />
+          <FormInput type='password' placeholder='비밀번호를 재입력하세요' />
+        </div>
+      </div>
+      <LinkButton route='/join?step=3'>다음</LinkButton>
+    </div>
   );
 }
 

--- a/src/components/join/step2/Step2.tsx
+++ b/src/components/join/step2/Step2.tsx
@@ -1,8 +1,16 @@
 import LinkButton from '@/components/common/button/LinkButton';
 import FormInput from '@/components/common/form/FormInput';
+import { FORM_ERROR_MSG } from '@/constants/formMsg';
 import React from 'react';
+import { useFormContext } from 'react-hook-form';
 
 function Step2() {
+  const {
+    watch,
+    trigger,
+    formState: { errors },
+  } = useFormContext();
+
   return (
     <div className='p-page flex h-full flex-col justify-between'>
       <div className='flex flex-col gap-[36px]'>
@@ -10,17 +18,61 @@ function Step2() {
           type='email'
           placeholder='이메일을 입력하세요'
           title='이메일'
+          fieldName='email'
+          options={{
+            required: true,
+            pattern: {
+              value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/i,
+              message: '이메일 형식을 확인해주세요.',
+            },
+            onBlur: () => {
+              trigger('email');
+              // 이메일 중복 확인
+            },
+          }}
         />
-        <div>
+        <div className='flex flex-col gap-[8px]'>
           <FormInput
             type='password'
             placeholder='8~15자 영문 대소문자, 숫자 포함'
             title='비밀번호'
+            fieldName='password'
+            options={{
+              pattern: {
+                value: /^(?=.[A-Z])(?=.[a-z])(?=.*\d)[A-Za-z\d]{8,15}$/i,
+                message: '8~15자의 영문 대소문자, 숫자를 조합하세요.',
+              },
+            }}
           />
-          <FormInput type='password' placeholder='비밀번호를 재입력하세요' />
+          <FormInput
+            type='password'
+            placeholder='비밀번호를 재입력하세요'
+            fieldName='passwordCheck'
+            options={{
+              validate: {
+                matches: (value: string) =>
+                  value === watch('password') || '비밀번호가 일치하지 않아요.',
+              },
+              onChange: () => {
+                trigger('passwordCheck');
+              },
+            }}
+          />
         </div>
       </div>
-      <LinkButton route='/join?step=3'>다음</LinkButton>
+      <LinkButton
+        route='/join?step=3'
+        disabled={Boolean(
+          !watch('email') ||
+            !watch('password') ||
+            !watch('passwordCheck') ||
+            errors.email ||
+            errors.password ||
+            errors.passwordCheck
+        )}
+      >
+        다음
+      </LinkButton>
     </div>
   );
 }

--- a/src/components/join/step2/Step2.tsx
+++ b/src/components/join/step2/Step2.tsx
@@ -1,6 +1,5 @@
-import LinkButton from '@/components/common/button/LinkButton';
+import FormButton from '@/components/common/form/FormButton';
 import FormInput from '@/components/common/form/FormInput';
-import { FORM_ERROR_MSG } from '@/constants/formMsg';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 
@@ -12,56 +11,60 @@ function Step2() {
   } = useFormContext();
 
   return (
-    <div className='p-page flex h-full flex-col justify-between'>
-      <div className='flex flex-col gap-[36px]'>
-        <FormInput
-          type='email'
-          placeholder='이메일을 입력하세요'
-          title='이메일'
-          fieldName='email'
-          options={{
-            required: true,
-            pattern: {
-              value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/i,
-              message: '이메일 형식을 확인해주세요.',
-            },
-            onBlur: () => {
-              trigger('email');
-              // 이메일 중복 확인
-            },
-          }}
-        />
-        <div className='flex flex-col gap-[8px]'>
+    <div className='pb-page flex h-full w-full flex-col justify-between'>
+      <div className='p-page flex w-full flex-col'>
+        <div className='flex flex-col gap-[36px]'>
           <FormInput
-            type='password'
-            placeholder='8~15자 영문 대소문자, 숫자 포함'
-            title='비밀번호'
-            fieldName='password'
+            type='email'
+            placeholder='이메일을 입력하세요'
+            title='이메일'
+            fieldName='email'
             options={{
+              required: true,
               pattern: {
-                value: /^(?=.[A-Z])(?=.[a-z])(?=.*\d)[A-Za-z\d]{8,15}$/i,
-                message: '8~15자의 영문 대소문자, 숫자를 조합하세요.',
+                value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/i,
+                message: '이메일 형식을 확인해주세요.',
+              },
+              onBlur: () => {
+                trigger('email');
+                // 이메일 중복 확인
               },
             }}
           />
-          <FormInput
-            type='password'
-            placeholder='비밀번호를 재입력하세요'
-            fieldName='passwordCheck'
-            options={{
-              validate: {
-                matches: (value: string) =>
-                  value === watch('password') || '비밀번호가 일치하지 않아요.',
-              },
-              onChange: () => {
-                trigger('passwordCheck');
-              },
-            }}
-          />
+          <div className='flex flex-col gap-[8px]'>
+            <FormInput
+              type='password'
+              placeholder='8~15자 영문 대소문자, 숫자 포함'
+              title='비밀번호'
+              fieldName='password'
+              options={{
+                pattern: {
+                  value: /^(?=.[A-Z])(?=.[a-z])(?=.*\d)[A-Za-z\d]{8,15}$/i,
+                  message: '8~15자의 영문 대소문자, 숫자를 조합하세요.',
+                },
+              }}
+            />
+            <FormInput
+              type='password'
+              placeholder='비밀번호를 재입력하세요'
+              fieldName='passwordCheck'
+              options={{
+                validate: {
+                  matches: (value: string) =>
+                    value === watch('password') ||
+                    '비밀번호가 일치하지 않아요.',
+                },
+                onChange: () => {
+                  trigger('passwordCheck');
+                },
+              }}
+            />
+          </div>
         </div>
       </div>
-      <LinkButton
+      <FormButton
         route='/join?step=3'
+        isTyping={false}
         disabled={Boolean(
           !watch('email') ||
             !watch('password') ||
@@ -70,9 +73,7 @@ function Step2() {
             errors.password ||
             errors.passwordCheck
         )}
-      >
-        다음
-      </LinkButton>
+      />
     </div>
   );
 }

--- a/src/constants/formMsg.ts
+++ b/src/constants/formMsg.ts
@@ -1,5 +1,0 @@
-export const FORM_ERROR_MSG = {
-  EMAIL: '이메일 형식을 확인해주세요.',
-  PASSWORD: '8~15자의 영문 대소문자, 숫자를 조합하세요.',
-  PASSWORD_CHECK: '비밀번호가 일치하지 않아요.',
-};

--- a/src/constants/formMsg.ts
+++ b/src/constants/formMsg.ts
@@ -1,0 +1,5 @@
+export const FORM_ERROR_MSG = {
+  EMAIL: '이메일 형식을 확인해주세요.',
+  PASSWORD: '8~15자의 영문 대소문자, 숫자를 조합하세요.',
+  PASSWORD_CHECK: '비밀번호가 일치하지 않아요.',
+};

--- a/src/types/form.d.ts
+++ b/src/types/form.d.ts
@@ -1,8 +1,8 @@
 export interface IJoinForm {
+  email: string;
+  password: string;
+  passwordCheck: string;
   terms: {
-    age: boolean;
-    termsOfUse: boolean;
-    privacyPolicy: boolean;
     marketing: boolean;
     ads: boolean;
   };


### PR DESCRIPTION
## 📍 작업 내용
- 폼 상태 관리 - react-hook-form
- 유효성 검사 - default:onBlur
- LinkButton 공통 컴포넌트 추가
    - Button은 button element, LinkButton은 Link element임.
    (onClick으로 무언가 작업을 해야할 땐 Button, 단순 이동인 경우 LinkButton 사용)
- Input focus → main color border 적용

<br/>

## 📍 구현 결과 (선택)
<img width="448" alt="스크린샷 2024-06-02 오전 12 39 32" src="https://github.com/Team-Frolog/Frolog_Web/assets/121474189/701ce385-6c06-42b4-8792-3f9d1c4f8d4e">

<br/>

## 📍 기타 사항
- 모바일 키보드 등장 시 버튼 변경 아직 구현 안한 상태

<br/>
