### PR TITLE
[Setting/#122]: lint, prettier, test ci 구축

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+on:
+  pull_request:
+    branches:
+      - dev
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ job.status }}
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: cache dependencies
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key:
+            ${{ runner.os }}-node-${{
+            hashFiles('**/package-lock.json')}}-storybook
+
+      - name: depedency install
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          echo "@team-frolog:registry=https://npm.pkg.github.com" >> .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.SHARED_PACKAGE_TOKEN }}" >> .npmrc
+          npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.SHARED_PACKAGE_TOKEN }}
+
+      - name: lint check
+        run: npm run lint
+
+      - name: prettier check
+        run: npm run prettier
+
+      - name: test check
+        run: npm run test
+
+      - name: publish to chromatic
+        id: chromatic
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,39 +1,39 @@
-name: Storybook Deployment
-on:
-  push:
-    branches:
-      - dev
-jobs:
-  storybook:
-    runs-on: ubuntu-latest
-    outputs:
-      status: ${{ job.status }}
-    steps:
-      - name: checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+# name: Storybook Deployment
+# on:
+#   push:
+#     branches:
+#       - dev
+# jobs:
+#   storybook:
+#     runs-on: ubuntu-latest
+#     outputs:
+#       status: ${{ job.status }}
+#     steps:
+#       - name: checkout repository
+#         uses: actions/checkout@v3
+#         with:
+#           fetch-depth: 0
 
-      - name: cache dependencies
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: '**/node_modules'
-          key:
-            ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json')}}-storybook
+#       - name: cache dependencies
+#         id: cache
+#         uses: actions/cache@v3
+#         with:
+#           path: '**/node_modules'
+#           key:
+#             ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json')}}-storybook
 
-      - name: depedency install
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          echo "@team-frolog:registry=https://npm.pkg.github.com" >> .npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.SHARED_PACKAGE_TOKEN }}" >> .npmrc
-          npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.SHARED_PACKAGE_TOKEN }}
+#       - name: depedency install
+#         if: steps.cache.outputs.cache-hit != 'true'
+#         run: |
+#           echo "@team-frolog:registry=https://npm.pkg.github.com" >> .npmrc
+#           echo "//npm.pkg.github.com/:_authToken=${{ secrets.SHARED_PACKAGE_TOKEN }}" >> .npmrc
+#           npm ci
+#         env:
+#           NODE_AUTH_TOKEN: ${{ secrets.SHARED_PACKAGE_TOKEN }}
 
-      - name: publish to chromatic
-        id: chromatic
-        uses: chromaui/action@v1
-        with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+#       - name: publish to chromatic
+#         id: chromatic
+#         uses: chromaui/action@v1
+#         with:
+#           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+#           token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "prettier": "prettier --check '**/*.{js,jsx,ts,tsx}'",
     "test": "jest --passWithNoTests --silent",
     "test:watch": "jest --watchAll --passWithNoTests",
     "coverage": "jest --coverage",


### PR DESCRIPTION
## 📍 작업 내용

CI 파이프라인 구축
- [x] lint
- [x] prettier
- [x] test

<br/>

## 📍 구현 결과 (선택)



<br/>

## 📍 기타 사항

lint, prettier, test 확인 기본 명령어만 추가했습니다.
storybook.yml은 주석처리 했습니다.

prettier 확인을 위해서 package.json에 prettier 명령어를 추가했습니다.

pr 단계에서 lint, test 결과를 report로 확인하는 과정은 필요 없을까요 ?
만약 report로 확인이 필요할 경우 test명령어를 `jest --passWithNoTests --silent --coverage` 로 통합하는게 어떨까요 ?
lint리포트는 reviewdog요거 사용하겠습니다.


<br/>
