### PR TITLE
[Refactor/#155]: dynamic import 적용

### DIFF
--- a/src/app/(default)/frolog-test/page.tsx
+++ b/src/app/(default)/frolog-test/page.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
-import { FrologTest } from '@/features/FrologTest';
 import { Metadata } from 'next';
+import dynamic from 'next/dynamic';
 
 export const metadata: Metadata = {
   title: '독서 성향 테스트',
 };
+
+const FrologTest = dynamic(
+  () => import('@/features/FrologTest/components/FrologTest')
+);
 
 function TestPage() {
   return <FrologTest />;

--- a/src/app/(profile-title)/how-to-install/page.tsx
+++ b/src/app/(profile-title)/how-to-install/page.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
-import { HowToInstall } from '@/features/Profile';
 import { Metadata } from 'next';
+import dynamic from 'next/dynamic';
 
 export const metadata: Metadata = {
   title: '앱 설치방법',
 };
+
+const HowToInstall = dynamic(
+  () => import('@/features/Profile/components/HowToInstall/HowToInstall')
+);
 
 function HowToInstallPage() {
   return <HowToInstall />;

--- a/src/app/(profile-title)/quit/page.tsx
+++ b/src/app/(profile-title)/quit/page.tsx
@@ -1,11 +1,15 @@
-import { QuitForm } from '@/features/Profile';
 import MainLayout from '@/layouts/MainLayout';
 import { Metadata } from 'next';
+import dynamic from 'next/dynamic';
 import React from 'react';
 
 export const metadata: Metadata = {
   title: '회원탈퇴',
 };
+
+const QuitForm = dynamic(
+  () => import('@/features/Profile/components/Quit/QuitForm')
+);
 
 function QuitPage() {
   return (

--- a/src/app/(profile-title)/terms/page.tsx
+++ b/src/app/(profile-title)/terms/page.tsx
@@ -1,11 +1,15 @@
-import { TermsMenu } from '@/features/Profile';
 import MainLayout from '@/layouts/MainLayout';
 import { Metadata } from 'next';
+import dynamic from 'next/dynamic';
 import React from 'react';
 
 export const metadata: Metadata = {
   title: '이용약관',
 };
+
+const TermsMenu = dynamic(
+  () => import('@/features/Profile/components/Terms/TermsMenu')
+);
 
 function TermsPage() {
   return (

--- a/src/app/(user)/[userId]/profile/edit/page.tsx
+++ b/src/app/(user)/[userId]/profile/edit/page.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ProfileEditForm } from '@/features/Profile';
 import { Metadata } from 'next';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/utils/auth/nextAuth';
@@ -10,6 +9,7 @@ import {
 } from '@tanstack/react-query';
 import { GetProfileDetail } from '@frolog/frolog-api';
 import { QUERY_KEY } from '@/constants/query';
+import dynamic from 'next/dynamic';
 
 export const metadata: Metadata = {
   title: '프로필 수정',
@@ -24,6 +24,10 @@ export const metadata: Metadata = {
     },
   },
 };
+
+const ProfileEditForm = dynamic(
+  () => import('@/features/Profile/components/Profile/ProfileEditForm')
+);
 
 interface Props {
   params: {

--- a/src/app/(user)/[userId]/profile/follows/page.tsx
+++ b/src/app/(user)/[userId]/profile/follows/page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { FollowPage } from '@/features/Profile';
 import { Metadata } from 'next';
+import dynamic from 'next/dynamic';
 
 export const metadata: Metadata = {
   title: '팔로우',
@@ -15,6 +15,10 @@ export const metadata: Metadata = {
     },
   },
 };
+
+const FollowPage = dynamic(
+  () => import('@/features/Profile/components/FollowList/FollowPage')
+);
 
 interface Props {
   params: {

--- a/src/app/(user)/[userId]/profile/setting/page.tsx
+++ b/src/app/(user)/[userId]/profile/setting/page.tsx
@@ -1,6 +1,10 @@
 import TitleHeader from '@/components/Header/TitleHeader';
-import { Menu } from '@/features/Profile';
 import MainLayout from '@/layouts/MainLayout';
+import dynamic from 'next/dynamic';
+
+const Menu = dynamic(() => import('@/features/Profile/components/Menu/Menu'), {
+  ssr: false,
+});
 
 async function ProfileSettingPage() {
   return (

--- a/src/features/Profile/components/FollowList/FollowList.tsx
+++ b/src/features/Profile/components/FollowList/FollowList.tsx
@@ -10,7 +10,6 @@ import { useProfileDetail } from '../../hooks/useProfileDetail';
 const Followers = dynamic(
   () => import('@/features/Profile/components/FollowList/Followers'),
   {
-    ssr: false,
     loading: () => <FollowListSkeleton />,
   }
 );
@@ -18,7 +17,6 @@ const Followers = dynamic(
 const Followings = dynamic(
   () => import('@/features/Profile/components/FollowList/Followings'),
   {
-    ssr: false,
     loading: () => <FollowListSkeleton />,
   }
 );

--- a/src/modules/BottomSheet/index.tsx
+++ b/src/modules/BottomSheet/index.tsx
@@ -2,7 +2,11 @@
 
 import { createRoot } from 'react-dom/client';
 import { BottomSheetKeys } from '@/data/ui/bottomSheet';
-import BottomSheetContainer from './BottomSheetContainer';
+import dynamic from 'next/dynamic';
+
+const BottomSheetContainer = dynamic(() => import('./BottomSheetContainer'), {
+  ssr: false,
+});
 
 export interface BottomSheetProps {
   /** 바텀시트 데이터 객체 키 */


### PR DESCRIPTION
## 📍 작업 내용

> dynamic import를 적용해 성능 최적화 리팩토링을 진행했습니다.

## dynamic import 언제 사용할까 ?
> 아래 내용은 개인적으로 학습한 내용이라 보충이 필요한 경우 첨언 부탁드려요.
### Yes

1. **무거운 라이브러리를 로딩할때**
    
    ⇒ 초기 번들 크기를 줄이기 위해서 필요할 때만 로드한다.
    
2. 클라이언트 전용 모듈
    
    ⇒ 서버 사이드 렌더링이 필요 없는 코드, 컴포넌트 로드.
    
3. 사용자 인터랙션 후 로드
    
    ⇒ 버튼 클릭, 스크롤 시점에서만 컴포넌트를 로드한다.
    

> dynamic import를 활용한 코드 스플리팅은 초기 번들에 코드를 포함시키지 않아 초기 로딩속도를 향상시킨다는 장점이 있지만,
반대로 각각의 스플리팅된 코드들을 따로 불러오기 위해 별도의 네트워크 요청이 필요하다.
> 

### No

1. 자주 사용되는 작은 크기의 컴포넌트
    
    ⇒ 버튼, 아이콘 등 반복적인 추가 네트워크 요청에 성능이 저하될 수 있음.
    
2. 페이지의 핵심 UI 요소
    
    ⇒ 초기 화면에 보여줘야 하는 주요 컴포넌트는 부적절함.

---
위 기준을 참고하여 우리 프로젝트에 어떻게 적용하는 게 좋을까 고심한 끝에 아래 2가지 지표를 설정했고, 각 지표에 부합하는 페이지, 컴포넌트에 대해서 dynamic import를 적용했습니다.

1. 사용자에게 노출이 적은 페이지
2. 사용자 인터렉션에 의해 로드되는 페이지 및 컴포넌트

위 지표에 따라 선정된 페이지 및 컴포넌트는 아래와 같습니다.

1. 사용자에게 노출이 적은 페이지
    1. frolog-test
    2. how-to-install
    4. quit
    5. terms
2. 사용자의 인터렉션에 의해 로드되는 컴포넌트
    1. profile/setting
    2. profile/edit
    3. profile/follows
    4. bottomsheet component


<br/>

## 📍 구현 결과 (선택)
결과적으로 First Load JS의 용량이 눈에띄게 감소했고, 이는 초기 로딩 속도 증가를 의미합니다.

**노출 횟수가 적은 페이지**

- frolog-test : 279KB → 273KB
- howtoinstall : 1.51MB → 1.21MB
- quit : 1.51MB → 284KB
- terms : 1.51MB → 157KB

**유저 인터랙션 로드 페이지 및 컴포넌트**

- profile/setting : 1.51MB → 225KB
- profile/follows : 1.51MB → 269KB
- profile/edit : 1.52MB → 364KB
- bottomsheet 컴포넌트 : 전체적으로 1KB 감소

![스크린샷 2025-03-07 오후 2 04 29](https://github.com/user-attachments/assets/5141f90c-2dd8-4555-ab90-15f05c3eb0c1)
_[Before]_

![스크린샷 2025-03-07 오후 4 52 18](https://github.com/user-attachments/assets/b2f58c5e-e8ab-4cc3-b9fe-903dd5fa95e8)
_[After]_

<br/>

## 📍 기타 사항

리팩토링을 진행하며 `ssr : false`옵션을 넣고 진행한 컴포넌트와 넣지 않은 컴포넌트가 있습니다.
이 둘의 차이는 완전하게 클라이언트 사이드 전용 모듈이라고 판단한 경우입니다. (ex: BottomSheet 컴포넌트)

검토 부탁드리며 지민님 의견도 부탁드려요.

<br/>
