### PR TITLE
[Feat/#167]: WebView Theme 메세지 전달 구현

### DIFF
--- a/src/app/(default)/well-search/page.tsx
+++ b/src/app/(default)/well-search/page.tsx
@@ -14,6 +14,7 @@ async function WellSearchPage() {
           type='no_border'
           theme='gray'
           hasButton={false}
+          webviewBgColor='bg-gray-300'
         />
         <div className='sticky left-0 top-[60px] z-60 flex w-full flex-col gap-[16px] bg-gray-300 px-[24px] pb-[12px]'>
           <SearchInput

--- a/src/app/(main)/book/[id]/page.tsx
+++ b/src/app/(main)/book/[id]/page.tsx
@@ -53,6 +53,7 @@ async function BookPage({ params: { id } }: Props) {
         theme='dark'
         title='도서 상세 페이지'
         hasButton={false}
+        webviewBgColor='black'
       />
       <MainLayout>
         <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/components/HOC/WithWebViewTheme.tsx
+++ b/src/components/HOC/WithWebViewTheme.tsx
@@ -1,0 +1,20 @@
+import React, { ReactNode, useEffect } from 'react';
+
+interface Props {
+  children: ReactNode;
+  bgColor: string;
+}
+
+function WithWebViewTheme({ children, bgColor }: Props) {
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.ReactNativeWebView) {
+      window.ReactNativeWebView.postMessage(
+        JSON.stringify({ type: 'THEME', data: bgColor })
+      );
+    }
+  }, []);
+
+  return <>{children}</>;
+}
+
+export default WithWebViewTheme;

--- a/src/components/Header/BackHeader.tsx
+++ b/src/components/Header/BackHeader.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { useRouter } from 'next/navigation';
+import WithWebViewTheme from '@/components/HOC/WithWebViewTheme';
 import BackButton from '../Button/BackButton';
 
 /** 뒤로가기 헤더
@@ -12,9 +13,11 @@ function BackHeader() {
   const router = useRouter();
 
   return (
-    <header className='header-sticky duration-50 z-70 flex justify-between border-b-[0.5px] border-gray-400 bg-white p-[24px] transition-all'>
-      <BackButton onClick={() => router.back()} fill='#727484' />
-    </header>
+    <WithWebViewTheme bgColor='white'>
+      <header className='header-sticky duration-50 z-70 flex justify-between border-b-[0.5px] border-gray-400 bg-white p-[24px] transition-all'>
+        <BackButton onClick={() => router.back()} fill='#727484' />
+      </header>
+    </WithWebViewTheme>
   );
 }
 

--- a/src/components/Header/DetailHeader.tsx
+++ b/src/components/Header/DetailHeader.tsx
@@ -7,6 +7,7 @@ import { useUserId } from '@/store/sessionStore';
 import { motion } from 'framer-motion';
 import { getPath } from '@/utils/getPath';
 import { useCustomRouter } from '@/hooks/useCustomRouter';
+import WithWebViewTheme from '@/components/HOC/WithWebViewTheme';
 import WithConditionalRendering from '../HOC/WithConditionalRendering';
 
 interface Props {
@@ -20,25 +21,27 @@ function DetailHeader({ profileUserId }: Props) {
   const isRootUser = userId === profileUserId;
 
   return (
-    <ResponsiveHeaderLayout onClick={() => router.back()}>
-      <WithConditionalRendering condition={!isRootUser}>
-        <div className='flex flex-1 justify-end'>
-          <motion.button
-            type='button'
-            whileTap={{ scale: 0.9 }}
-            onClick={() =>
-              runWhenLoggedIn(
-                () => navigate(getPath.profile(profileUserId)),
-                'feed'
-              )
-            }
-            className='flex items-center gap-[6px] text-body-lg-bold text-main'
-          >
-            우물 놀러가기
-          </motion.button>
-        </div>
-      </WithConditionalRendering>
-    </ResponsiveHeaderLayout>
+    <WithWebViewTheme bgColor='black'>
+      <ResponsiveHeaderLayout onClick={() => router.back()}>
+        <WithConditionalRendering condition={!isRootUser}>
+          <div className='flex flex-1 justify-end'>
+            <motion.button
+              type='button'
+              whileTap={{ scale: 0.9 }}
+              onClick={() =>
+                runWhenLoggedIn(
+                  () => navigate(getPath.profile(profileUserId)),
+                  'feed'
+                )
+              }
+              className='flex items-center gap-[6px] text-body-lg-bold text-main'
+            >
+              우물 놀러가기
+            </motion.button>
+          </div>
+        </WithConditionalRendering>
+      </ResponsiveHeaderLayout>
+    </WithWebViewTheme>
   );
 }
 

--- a/src/components/Header/FormHeader.tsx
+++ b/src/components/Header/FormHeader.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import { STORAGE_KEY } from '@/constants/storage';
 import { PAGES } from '@/constants/page';
 import { BackIcon } from 'public/icons';
+import WithWebViewTheme from '@/components/HOC/WithWebViewTheme';
 
 /** 각종 폼에 할용되는 타이틀 헤더
  * - FormLayout에 적용됩니다.
@@ -29,16 +30,18 @@ function FormHeader() {
   };
 
   return (
-    <header className='block w-full gap-3 p-[24px] pb-0'>
-      <button
-        type='button'
-        className='cursor-pointer'
-        onClick={handleClickBack}
-      >
-        <BackIcon fill='#B3B6C5' />
-      </button>
-      <h3 className='text-heading-md-bold'>{title}</h3>
-    </header>
+    <WithWebViewTheme bgColor='black'>
+      <header className='block w-full gap-3 p-[24px] pb-0'>
+        <button
+          type='button'
+          className='cursor-pointer'
+          onClick={handleClickBack}
+        >
+          <BackIcon fill='#B3B6C5' />
+        </button>
+        <h3 className='text-heading-md-bold'>{title}</h3>
+      </header>
+    </WithWebViewTheme>
   );
 }
 

--- a/src/components/Header/ProfileTitleHeader.tsx
+++ b/src/components/Header/ProfileTitleHeader.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import WithWebViewTheme from '@/components/HOC/WithWebViewTheme';
 import { PAGES } from '@/constants/page';
 import { usePathname, useRouter } from 'next/navigation';
 import { BackIcon } from 'public/icons';
@@ -37,16 +38,18 @@ function ProfileTitleHeader() {
   };
 
   return (
-    <header className='block w-full gap-[12px] bg-white px-page pb-[20px] pt-[24px]'>
-      <button
-        type='button'
-        className='cursor-pointer'
-        onClick={() => router.back()}
-      >
-        <BackIcon fill='#727384' />
-      </button>
-      {renderTitle()}
-    </header>
+    <WithWebViewTheme bgColor='white'>
+      <header className='block w-full gap-[12px] bg-white px-page pb-[20px] pt-[24px]'>
+        <button
+          type='button'
+          className='cursor-pointer'
+          onClick={() => router.back()}
+        >
+          <BackIcon fill='#727384' />
+        </button>
+        {renderTitle()}
+      </header>
+    </WithWebViewTheme>
   );
 }
 

--- a/src/components/Header/StoreHeader.tsx
+++ b/src/components/Header/StoreHeader.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { STORE_TABS } from '@/constants/tabs';
 import { useRouter } from 'next/navigation';
 import { useWallet } from '@/features/Store/hooks/useWallet';
+import WithWebViewTheme from '@/components/HOC/WithWebViewTheme';
 import BackButton from '../Button/BackButton';
 import TabMenu from '../Tab/TabMenu';
 
@@ -20,15 +21,17 @@ function StoreHeader({ userId }: Props) {
   const { points } = useWallet(userId);
 
   return (
-    <header className='duration-50 block h-fit w-full gap-3 bg-white p-[24px] transition-all'>
-      <BackButton fill='#727384' onClick={() => router.back()} />
-      <div className='flex items-center justify-between'>
-        <TabMenu tabs={STORE_TABS} theme='light' />
-        <div className='h-fit rounded-[50px] bg-gray-300 px-[14px] py-[8px] text-title-lg-bold'>
-          {points?.toLocaleString()} P
+    <WithWebViewTheme bgColor='white'>
+      <header className='duration-50 block h-fit w-full gap-3 bg-white p-[24px] transition-all'>
+        <BackButton fill='#727384' onClick={() => router.back()} />
+        <div className='flex items-center justify-between'>
+          <TabMenu tabs={STORE_TABS} theme='light' />
+          <div className='h-fit rounded-[50px] bg-gray-300 px-[14px] py-[8px] text-title-lg-bold'>
+            {points?.toLocaleString()} P
+          </div>
         </div>
-      </div>
-    </header>
+      </header>
+    </WithWebViewTheme>
   );
 }
 

--- a/src/components/Header/TitleHeader.tsx
+++ b/src/components/Header/TitleHeader.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { bottomSheet } from '@/modules/BottomSheet';
+import WithWebViewTheme from '@/components/HOC/WithWebViewTheme';
 import BackButton from '../Button/BackButton';
 import WithConditionalRendering from '../HOC/WithConditionalRendering';
 
@@ -17,6 +18,7 @@ interface Props {
   title: string;
   /** 테마 색상 */
   theme: 'dark' | 'light' | 'gray';
+  webviewBgColor?: string;
   /** 추가 버튼 핸들러 함수 */
   onClick?: () => void;
   /** 뒤로가기 핸들러 (주어지지 않은 경우 내부 함수 사용) */
@@ -31,6 +33,7 @@ function TitleHeader({
   isDisabled,
   theme,
   title,
+  webviewBgColor = 'white',
   onClick,
   onClickBack,
   hasButton = true,
@@ -70,30 +73,32 @@ function TitleHeader({
   };
 
   return (
-    <header
-      id='header'
-      className={`header-sticky duration-50 z-70 flex justify-between px-[24px] py-[20px] transition-all ${getThemeColor(theme)} ${type === 'no_border' ? 'border-0' : 'border-b-[0.5px] border-gray-400'}`}
-    >
-      <BackButton
-        onClick={onClickBack || handleClick}
-        fill={theme === 'light' ? '#727484' : '#B3B6C5'}
-      />
-      <h2
-        id='selected'
-        className='absolute inset-x-0 top-1/2 mx-auto w-[70%] -translate-y-1/2 truncate text-center text-body-xl-bold'
+    <WithWebViewTheme bgColor={webviewBgColor}>
+      <header
+        id='header'
+        className={`header-sticky duration-50 z-70 flex justify-between px-[24px] py-[20px] transition-all ${getThemeColor(theme)} ${type === 'no_border' ? 'border-0' : 'border-b-[0.5px] border-gray-400'}`}
       >
-        {title}
-      </h2>
-      <WithConditionalRendering condition={hasButton}>
-        <button
-          type={type === 'default' ? 'button' : 'submit'}
-          onClick={type === 'default' ? onClick : undefined}
-          className={`text-body-lg-bold text-main ${(type === 'edit' || type === 'write') && isDisabled && 'pointer-events-none opacity-50'}`}
+        <BackButton
+          onClick={onClickBack || handleClick}
+          fill={theme === 'light' ? '#727484' : '#B3B6C5'}
+        />
+        <h2
+          id='selected'
+          className='absolute inset-x-0 top-1/2 mx-auto w-[70%] -translate-y-1/2 truncate text-center text-body-xl-bold'
         >
-          {type === 'default' ? '수정' : '저장'}
-        </button>
-      </WithConditionalRendering>
-    </header>
+          {title}
+        </h2>
+        <WithConditionalRendering condition={hasButton}>
+          <button
+            type={type === 'default' ? 'button' : 'submit'}
+            onClick={type === 'default' ? onClick : undefined}
+            className={`text-body-lg-bold text-main ${(type === 'edit' || type === 'write') && isDisabled && 'pointer-events-none opacity-50'}`}
+          >
+            {type === 'default' ? '수정' : '저장'}
+          </button>
+        </WithConditionalRendering>
+      </header>
+    </WithWebViewTheme>
   );
 }
 

--- a/src/components/Header/WellEntryHeader.tsx
+++ b/src/components/Header/WellEntryHeader.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import React from 'react';
+import WithWebViewTheme from '@/components/HOC/WithWebViewTheme';
 import BackButton from '../Button/BackButton';
 
 interface Props {
@@ -24,27 +25,29 @@ function WellEntryHeader({
   const router = useRouter();
 
   return (
-    <header className={`flex h-fit w-full ${bgColor || 'bg-white'}`}>
-      {hasBackButton && (
-        <BackButton
-          type='bg'
-          safeArea='back-button'
-          onClick={() => router.back()}
-        />
-      )}
-      <div className='safe-header pointer-events-none absolute left-0 z-60 flex w-full justify-between gap-[80px]'>
-        <div className='side-header-left' />
-        <div className='side-header-right' />
-      </div>
-      {title && (
-        <div className='flex h-fit w-full px-page py-[20px] pt-[50px]'>
-          <h1 className='w-fit max-w-[250px] text-start text-heading-md-bold'>
-            {title}
-          </h1>
+    <WithWebViewTheme bgColor='black'>
+      <header className={`flex h-fit w-full ${bgColor || 'bg-white'}`}>
+        {hasBackButton && (
+          <BackButton
+            type='bg'
+            safeArea='back-button'
+            onClick={() => router.back()}
+          />
+        )}
+        <div className='safe-header pointer-events-none absolute left-0 z-60 flex w-full justify-between gap-[80px]'>
+          <div className='side-header-left' />
+          <div className='side-header-right' />
         </div>
-      )}
-      {children}
-    </header>
+        {title && (
+          <div className='flex h-fit w-full px-page py-[20px] pt-[50px]'>
+            <h1 className='w-fit max-w-[250px] text-start text-heading-md-bold'>
+              {title}
+            </h1>
+          </div>
+        )}
+        {children}
+      </header>
+    </WithWebViewTheme>
   );
 }
 

--- a/src/features/Well/components/Well/WellTitle.tsx
+++ b/src/features/Well/components/Well/WellTitle.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import { PAGES } from '@/constants/page';
+import WithWebViewTheme from '@/components/HOC/WithWebViewTheme';
 import WellActionButton from './Pointing/WellActionButton';
 
 interface Props {
@@ -27,29 +28,31 @@ function WellTitle({
   isRootUser = false,
 }: Props) {
   return (
-    <div className='flex-col-center relative flex w-full shrink-0'>
-      <div className='pointer-events-none absolute left-0 top-0 z-10 flex w-full justify-between overscroll-contain'>
-        <div className='well-header-left' />
-        <div className='well-header-right' />
+    <WithWebViewTheme bgColor='black'>
+      <div className='flex-col-center relative flex w-full shrink-0'>
+        <div className='pointer-events-none absolute left-0 top-0 z-10 flex w-full justify-between overscroll-contain'>
+          <div className='well-header-left' />
+          <div className='well-header-right' />
+        </div>
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.5 }}
+          className='flex-column items-center gap-[20px] py-[50px]'
+        >
+          <h1 className='text-title-xl-bold'>{title}</h1>
+          {isRootUser && (
+            <WellActionButton
+              btnName='책 추가하기'
+              wellId={wellId}
+              href={PAGES.SEARCH}
+              isPointing={isPointing}
+              itemCount={itemCount}
+            />
+          )}
+        </motion.div>
       </div>
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.5 }}
-        className='flex-column items-center gap-[20px] py-[50px]'
-      >
-        <h1 className='text-title-xl-bold'>{title}</h1>
-        {isRootUser && (
-          <WellActionButton
-            btnName='책 추가하기'
-            wellId={wellId}
-            href={PAGES.SEARCH}
-            isPointing={isPointing}
-            itemCount={itemCount}
-          />
-        )}
-      </motion.div>
-    </div>
+    </WithWebViewTheme>
   );
 }
 

--- a/src/types/webview.d.ts
+++ b/src/types/webview.d.ts
@@ -1,0 +1,7 @@
+export declare global {
+  interface Window {
+    ReactNativeWebView: {
+      postMessage: (value: string) => void;
+    };
+  }
+}


### PR DESCRIPTION
## 📍 작업 내용

> 상태바 style 이슈와 건의하기 페이지가 상태바와 겹치는 이슈를 해결했습니다.

- [x] WithWebViewTheme HOC 구현
- [x] 각 헤더별 WithWebViewTheme 적용
- [x] 건의하기 페이지 외부 브라우저 이용 열기 기능 구현

이번 기능 구현을 위해 저번에 말씀드린 **페이지 이동시 theme정보를 RN WebView로 메세지 전송** 방법을 사용했습니다.
단순히 WellEntryHeader를 포함되어 있는 페이지에 한해서만 해당 페이지로 이동시 메세지를 보내면 되겠다 라고 생각했지만, 해당 헤더 뿐만 아니라 다른 페이지에서도 검은색 또는 회색 헤더를 포함하는 경우가 있었습니다.
따라서  각 페이지별로 사용되는 헤더들을 파악해 헤더의 색상을 WithWebViewTheme HOC으로 넘겨주었습니다.

WebView에 메세지를 전달하는 로직을 HOC를 이용해 구현했습니다.
일반적으로 각 컴포넌트별로 로직을 추가해 구현할 수 있었지만, 다음과 같은 이유로 HOC로 별도 구현했습니다.

1. 웹 페이지를 위해 렌더링 되는 컴포넌트 내부에서 WebView를 위한 코드를 분리하기 위함.
2. 공통으로 사용되는 로직을 재사용하기 위함.
3. 명확한 목적을 명시한 컴포넌트 네이밍으로 웹 컴포넌트 코드 흐름의 방해를 제거하기 위함.

더 자세한 내용은 아래 문서를 참고 부탁드립니다
[React Native StatusBar theme 핸들링](https://www.notion.so/React-Native-StatusBar-theme-1c3148c5cb69809d9c77cceb818339f4)
감사합니다.

<br/>

## 📍 구현 결과 (선택)

![앱 상태바 변경](https://github.com/user-attachments/assets/9a2b83ba-aa43-4290-9f53-3ae3955a6d13)

_앱 상태바 변경 Android_

![앱 건의하기](https://github.com/user-attachments/assets/62eb8a49-dd24-4e5a-869d-3bb4dafd6474)

_앱 건의하기 Android_

<br/>

## 📍 기타 사항

추가적으로 앱 테스트를 localhost:3000으로 프로젝트를 실행하고 WebView의 uri를 localhost:3000으로 참조해 테스트를 진행하는데 알 수 없는 오류로 인해 현재 iOS 테스트를 진행하지 못하고 있습니다.

따라서 저번 말씀해주신 dev 배포 환경을 이용해서 테스트를 진행해야 할것 같습니다.
해당 오류의 원인을 파악하려고 이방법 저방법을 찾아봤지만, 아직 해결법이 없는것 같습니다.

[관련 react-native-webview 이슈](https://github.com/react-native-webview/react-native-webview/issues/3181)

<br/>
