### PR TITLE
[HOTFIX]: profile redirect 버그 수정

### DIFF
--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -47,7 +47,7 @@ function NavigationBar() {
     },
     {
       label: NAV_ITEM.profile.label,
-      href: getPath.profile(userId ?? ''),
+      href: userId ? getPath.profile(userId) : PAGES.PROFILE,
       icon: ProfileIcon,
       navKey: NAV_ITEM.profile.key,
     },


### PR DESCRIPTION
## 📍 작업 내용
> profile redirect 버그 수정

Navigation Bar에서 Profile 클릭 시 페이지가 정상적으로 나타나지 않는 버그를 수정했습니다.

원인은 단순 라우팅 실수였던 것으로.... profile 페이지 경로 만들어주는 함수를 잘못 처리했어요.
userId가 없는 경우 문제가 있었네요.

```ts
profile: (userId: string) => `/${userId}${PAGES.PROFILE}`,
```

<br/>
