### PR TITLE
[HotFix/#178]: 릴리즈 이슈 수정

### DIFF
--- a/src/app/(store)/mission/page.tsx
+++ b/src/app/(store)/mission/page.tsx
@@ -6,15 +6,35 @@ import { IMAGES } from '@/constants/images';
 function MissionPage() {
   return (
     <>
-      <div className='flex w-full flex-col gap-[20px]'>
-        <div className='flex-column gap-[4px] rounded-[20px] bg-[#85DCFF] px-[20px] pt-[20px] text-white'>
-          <h5 className='text-title-xl-bold'>읽기 전/중 책 추가</h5>
+      <div className='flex-column w-full gap-[20px]'>
+        <div className='flex w-full flex-col gap-[20px]'>
+          <div className='flex-column gap-[4px] rounded-[20px] bg-[#85DCFF] px-[20px] pt-[20px] text-white'>
+            <h5 className='text-title-xl-bold'>읽기 전/중 책 추가</h5>
+            <div className='flex-column'>
+              <div className='flex w-full justify-between'>
+                <span className='text-body-lg-bold'>1일 최대 20p</span>
+                <span className='self-end text-body-lg'>1회 10p</span>
+              </div>
+              <Image
+                src={IMAGES.frog.reading.before}
+                alt='reading book frog'
+                width={127}
+                height={62}
+                className='self-end pt-[16px]'
+              />
+            </div>
+          </div>
+        </div>
+        <div className='flex-column w-full gap-[4px] rounded-[20px] bg-[#FF8BCA] px-[20px] pt-[20px] text-white'>
+          <h5 className='text-title-xl-bold'>다 읽은 책 추가</h5>
           <div className='flex-column'>
-            <span className='text-body-lg-bold'>1일 최대 20p</span>
-            <span className='self-end text-body-lg'>1회 10p</span>
+            <div className='flex w-full justify-between'>
+              <span className='text-body-lg-bold'>1일 최대 20p</span>
+              <span className='self-end text-body-lg'>1회 20p</span>
+            </div>
             <Image
-              src={IMAGES.frog.reading.before}
-              alt='reading book frog'
+              src={IMAGES.frog.reading.after}
+              alt='read book frog'
               width={127}
               height={62}
               className='self-end pt-[16px]'
@@ -22,21 +42,6 @@ function MissionPage() {
           </div>
         </div>
       </div>
-      <div className='flex-column w-full gap-[4px] rounded-[20px] bg-[#FF8BCA] px-[20px] pt-[20px] text-white'>
-        <h5 className='text-title-xl-bold'>다 읽은 책 추가</h5>
-        <div className='flex-column'>
-          <span className='text-body-lg-bold'>1일 최대 20p</span>
-          <span className='self-end text-body-lg'>1회 20p</span>
-          <Image
-            src={IMAGES.frog.reading.after}
-            alt='read book frog'
-            width={127}
-            height={62}
-            className='self-end pt-[16px]'
-          />
-        </div>
-      </div>
-
       <Image
         src={IMAGES.frog.mission_frog}
         alt='mission frog'

--- a/src/app/(store)/mission/page.tsx
+++ b/src/app/(store)/mission/page.tsx
@@ -22,7 +22,7 @@ function MissionPage() {
           </div>
         </div>
       </div>
-      <div className='flex-column gap-[4px] rounded-[20px] bg-[#FF8BCA] px-[20px] pt-[20px] text-white'>
+      <div className='flex-column w-full gap-[4px] rounded-[20px] bg-[#FF8BCA] px-[20px] pt-[20px] text-white'>
         <h5 className='text-title-xl-bold'>다 읽은 책 추가</h5>
         <div className='flex-column'>
           <span className='text-body-lg-bold'>1일 최대 20p</span>

--- a/src/app/(user)/[userId]/profile/page.tsx
+++ b/src/app/(user)/[userId]/profile/page.tsx
@@ -1,4 +1,3 @@
-import ProfileFeedListSkeleton from '@/components/Fallback/Skeleton/Profile/ProfileFeedListSkeleton';
 import NavigationBar from '@/components/NavigationBar/NavigationBar';
 import MainLayout from '@/layouts/MainLayout';
 import { getIsRootUser } from '@/utils/auth/getIsRootUser';
@@ -37,9 +36,7 @@ async function UserProfilePage({ params: { userId } }: Props) {
             isRootUser={isRootUser}
           />
           {isRootUser ? (
-            <Suspense fallback={<ProfileFeedListSkeleton />}>
-              <ProfileFeed initialProfileFeed={initialProfileFeed} />
-            </Suspense>
+            <ProfileFeed initialProfileFeed={initialProfileFeed} />
           ) : (
             <Suspense fallback={<WellListSkeleton />}>
               <WellList

--- a/src/features/Book/components/BookList/BookListItem.tsx
+++ b/src/features/Book/components/BookList/BookListItem.tsx
@@ -31,6 +31,9 @@ function BookListItem({ bookData, onSaveScroll }: Props) {
     review_cnt,
   } = bookData;
 
+  const hasPosTag = tags_pos.length > 0;
+  const hasNegTag = tags_neg.length > 0;
+
   return (
     <CustomLink
       prefetch
@@ -76,16 +79,20 @@ function BookListItem({ bookData, onSaveScroll }: Props) {
                 />
               }
             >
-              <Tag
-                type='pros'
-                tagValue={getTagById('pros', tags_pos[0])!}
-                size='small'
-              />
-              <Tag
-                type='cons'
-                tagValue={getTagById('cons', tags_neg[0])!}
-                size='small'
-              />
+              {hasPosTag && (
+                <Tag
+                  type='pros'
+                  tagValue={getTagById('pros', tags_pos[0])!}
+                  size='small'
+                />
+              )}
+              {hasNegTag && (
+                <Tag
+                  type='cons'
+                  tagValue={getTagById('cons', tags_neg[0])!}
+                  size='small'
+                />
+              )}
             </WithConditionalRendering>
           </div>
           <span className='text-caption-bold text-gray-600'>

--- a/src/features/Book/components/BottomSheet/StateSelectSheet.tsx
+++ b/src/features/Book/components/BottomSheet/StateSelectSheet.tsx
@@ -20,12 +20,12 @@ function StateSelectSheet({
   handleAddReadingBook,
 }: Props) {
   return (
-    <div className='flex w-full flex-col gap-[28px] pb-[32px] pt-[28px] text-title-xl-bold text-gray-800'>
+    <div className='flex w-full flex-col gap-[28px] pb-[32px] pt-[28px] text-title-xl-bold text-gray-800 [@media(max-width:360px)]:text-title-lg-bold'>
       <button
         type='button'
         disabled={!!reviewCount}
         onClick={handleAddReadingBook}
-        className={`flex h-[95px] items-center justify-between gap-[20px] rounded-[12px] bg-gray-200 pl-[30px] pr-[10px] ${reviewCount ? 'opacity-10' : ''}`}
+        className={`flex h-[95px] items-center justify-between rounded-[12px] bg-gray-200 pl-[30px] pr-[10px] [@media(max-width:360px)]:pl-[20px] ${reviewCount ? 'opacity-10' : ''}`}
       >
         <span>읽기 전/중이에요</span>
         <div className='flex h-full items-end'>
@@ -40,7 +40,7 @@ function StateSelectSheet({
       <button
         type='button'
         onClick={handleAddReadBook}
-        className='flex h-[95px] items-center justify-between gap-[20px] rounded-[12px] bg-gray-200 pl-[30px] pr-[10px]'
+        className='flex h-[95px] items-center justify-between gap-[20px] rounded-[12px] bg-gray-200 pl-[30px] pr-[10px] [@media(max-width:360px)]:pl-[20px]'
       >
         <span>다 읽었어요</span>
         <div className='flex h-full items-end'>

--- a/src/features/Memo/hooks/useMemos.ts
+++ b/src/features/Memo/hooks/useMemos.ts
@@ -93,7 +93,7 @@ export const useMemos = (
     },
   });
 
-  const isEmpty = isFetched && data?.pages.length === 0;
+  const isEmpty = !data.pages || (isFetched && data?.pages.length === 0);
 
   return {
     memoList: data?.pages,

--- a/src/features/Profile/components/Feed/ProfileFeedItem.tsx
+++ b/src/features/Profile/components/Feed/ProfileFeedItem.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import React from 'react';
 import { getPath } from '@/utils/getPath';
 import { useUserId } from '@/store/sessionStore';
+import { useCustomRouter } from '@/hooks/useCustomRouter';
 
 interface Props {
   feedData: GetProfileFeedItem;
@@ -13,6 +14,8 @@ interface Props {
 /** 사용자 프로필 피드 아이템 */
 function ProfileFeedItem({ feedData }: Props) {
   const userId = useUserId();
+  const { navigate } = useCustomRouter();
+
   const { memoCount, reviewCount, wellId } = feedData;
   const { image, category, isbn } = feedData.book;
 
@@ -29,7 +32,8 @@ function ProfileFeedItem({ feedData }: Props) {
         alt='book cover'
         width={191}
         height={272}
-        className='flex-[8]'
+        className='flex-[8] cursor-pointer'
+        onClick={() => navigate(getPath.rootUserMemo(userId!, wellId!, isbn))}
       />
       <div className='flex flex-col gap-[1px]'>
         <FeedItemDetail

--- a/src/features/Profile/components/Profile/ProfilePageHeader.tsx
+++ b/src/features/Profile/components/Profile/ProfilePageHeader.tsx
@@ -20,7 +20,7 @@ function ProfilePageHeader({ isRootUser, userId }: Props) {
           type='button'
           whileTap={{ scale: 0.9 }}
           href={getPath.profileSetting(userId)}
-          className='absolute right-[24px] top-[24px] z-70'
+          className='absolute right-[28px] top-[35px] z-70'
         >
           <SettingIcon />
         </CustomMotionLink>

--- a/src/features/Review/hooks/useReviews.ts
+++ b/src/features/Review/hooks/useReviews.ts
@@ -61,7 +61,7 @@ export const useReviews = (
     },
   });
 
-  const isEmpty = data.reviews.length === 0;
+  const isEmpty = !data.reviews || data.reviews.length === 0;
 
   return {
     deleteReview: mutate,


### PR DESCRIPTION
## 📍 작업 내용

> 프로필 피드, 첫메모 릴리스 후 발생한 이슈를 수정했습니다.

- [x] 미션 ui 구현 에러
- [x] 프로필 탭 톱니바퀴 ui 위치 구현 에러
- [ ] 프로필에서 책 눌렀을 때, 책 관련 기록 삭제 팝업이 나와야 하는데, 우물에서 제거 팝업이 나옴
- [x] 메모, 리뷰 삭제시 404 error
- [x] 책 정보 단점 없을때 단점 키워드 UI 수정
- [x] 지금 이책은.. 바텀시트 ui 수정
- [x] 프로필 피드 아이템 클릭시 디폴트로 메모 상세 페이지로 이동
<br/>

## 📍 구현 결과 (선택)

<img width="270" alt="스크린샷 2025-05-31 오전 3 46 39" src="https://github.com/user-attachments/assets/31343223-a92c-4b90-8aef-be1cb02b2fdd" />

[이책은 지금 바텀시트]

<img width="449" alt="스크린샷 2025-05-31 오전 3 45 09" src="https://github.com/user-attachments/assets/435da4de-65d3-4dd9-b4b8-b7170ea1acfc" />

[미션 페이지]

<img width="450" alt="스크린샷 2025-05-31 오전 3 46 19" src="https://github.com/user-attachments/assets/00ad6121-9acd-4edf-8010-add0ce43410f" />

[책 정보 태그 없을 경우 분기처리]




<br/>

## 📍 기타 사항

```javascript
Unhandled Runtime Error
TypeError: Cannot read properties of undefined (reading 'length')

src/features/Review/hooks/useReviews.ts (64:31) @ length

  62 | });
  63 | 
> 64 | const isEmpty = data.reviews.length === 0;
     |                             ^
  65 | 
  66 | return {
  67 |   deleteReview: mutate,
```

지민님 `useReviews` `useMemos` 훅에서 delete 함수를 실행했을때 위처럼 오류가 발생하고 있어요.
오류의 원인은 하나뿐인 리뷰와 메모를 삭제하면 그다음 data에는 reviews와 pages 프로퍼티가 없어서 입니다.

그래서 isEmpty에 `!data.reviews` `!data.pages` 조건을 `||`로 추가해서 에러를 잡긴 했는데, 나중에 돌아 오시고 해당 에러 한번 체크 부탁드립니다 !

<br/>
