### PR TITLE
[Fix/#181]: 프로필 피드 설정 아이콘 위치 조정 및 책 추가하기 버튼 추가

### DIFF
--- a/src/components/Button/LinkButton.tsx
+++ b/src/components/Button/LinkButton.tsx
@@ -9,7 +9,7 @@ interface Props {
   children: React.ReactNode;
   route: string;
   disabled?: boolean;
-  theme?: 'normal' | 'light' | 'gray';
+  theme?: 'normal' | 'light' | 'gray' | 'ghost';
   extraClass?: string;
   isReplace?: boolean;
 }

--- a/src/features/Profile/components/Feed/NoProfileFeed.tsx
+++ b/src/features/Profile/components/Feed/NoProfileFeed.tsx
@@ -1,7 +1,11 @@
 import Image from 'next/image';
 import { IMAGES } from '@/constants/images';
+import Button from '@/components/Button/Button';
+import { useCustomRouter } from '@/hooks/useCustomRouter';
+import { PAGES } from '@/constants/page';
 
 function NoProfileFeed() {
+  const { navigate } = useCustomRouter('profile');
   return (
     <div className='mt-3 flex w-full flex-col items-center justify-center gap-[15px]'>
       <Image
@@ -16,6 +20,9 @@ function NoProfileFeed() {
           리뷰를 작성하면 여기에 표시됩니다.
         </p>
       </div>
+      <Button theme='normal' onClick={() => navigate(PAGES.SEARCH)}>
+        책 추가하기
+      </Button>
     </div>
   );
 }

--- a/src/features/Profile/components/Profile/Profile.tsx
+++ b/src/features/Profile/components/Profile/Profile.tsx
@@ -21,7 +21,7 @@ function Profile({ userId, isRootUser = false, profileDetail }: Props) {
       <UserType profileDetail={profileDetail} />
       {isRootUser && (
         <div className='flex px-page'>
-          <LinkButton route={getPath.profileEdit(userId)} theme='normal'>
+          <LinkButton route={getPath.profileEdit(userId)} theme='ghost'>
             프로필 편집
           </LinkButton>
         </div>

--- a/src/features/Profile/components/Profile/ProfilePageHeader.tsx
+++ b/src/features/Profile/components/Profile/ProfilePageHeader.tsx
@@ -15,15 +15,17 @@ function ProfilePageHeader({ isRootUser, userId }: Props) {
   return (
     <WellEntryHeader title='프로필' hasBackButton={!isRootUser}>
       {isRootUser && (
-        <CustomMotionLink
-          id='setting-button'
-          type='button'
-          whileTap={{ scale: 0.9 }}
-          href={getPath.profileSetting(userId)}
-          className='absolute right-[28px] top-[35px] z-70'
-        >
-          <SettingIcon />
-        </CustomMotionLink>
+        <div className='safe-header absolute left-[50%] z-70 flex w-[450px] translate-x-[-50%] gap-[20px] pt-[70px] mobile:left-0 mobile:w-full mobile:translate-x-0'>
+          <CustomMotionLink
+            id='setting-button'
+            type='button'
+            whileTap={{ scale: 0.9 }}
+            href={getPath.profileSetting(userId)}
+            className='absolute right-[28px] top-[28px] z-70'
+          >
+            <SettingIcon />
+          </CustomMotionLink>
+        </div>
       )}
     </WellEntryHeader>
   );

--- a/src/features/Profile/hooks/useProfileFeed.ts
+++ b/src/features/Profile/hooks/useProfileFeed.ts
@@ -29,8 +29,7 @@ export const useProfileFeed = (initialProfileFeed: GetProfileFeedRes) => {
       }),
     });
 
-  // const isEmpty = data.pages.length === 0;
-  const isEmpty = true;
+  const isEmpty = data.pages.length === 0;
 
   return {
     profileFeed: data.pages,

--- a/src/features/Profile/hooks/useProfileFeed.ts
+++ b/src/features/Profile/hooks/useProfileFeed.ts
@@ -29,7 +29,8 @@ export const useProfileFeed = (initialProfileFeed: GetProfileFeedRes) => {
       }),
     });
 
-  const isEmpty = data.pages.length === 0;
+  // const isEmpty = data.pages.length === 0;
+  const isEmpty = true;
 
   return {
     profileFeed: data.pages,

--- a/src/styles/buttons.css
+++ b/src/styles/buttons.css
@@ -19,6 +19,9 @@
   .button-error {
     @apply button-common bg-error text-white;
   }
+  .button-ghost {
+    @apply button-common border border-main bg-white text-main;
+  }
   .add-button-wrapper {
     @apply w-full px-page pb-[24px];
   }

--- a/src/utils/getButtonColor.ts
+++ b/src/utils/getButtonColor.ts
@@ -11,6 +11,8 @@ export const getButtonColor = (theme: string) => {
       return 'button-gray';
     case 'light':
       return 'button-light';
+    case 'ghost':
+      return 'button-ghost';
     default:
       return `button-common ${theme}`;
   }


### PR DESCRIPTION
## 📍 작업 내용

> 프로필 피드 설정 아이콘 위치 조정 및 책 추가하기 버튼 추가

- [x] 프로필 피드 책 추가하기 버튼 추가
- [x] 설정 아이콘 헤더 safe header 적용
- [x] 프로필 편집 버튼 스타일 수정

<br/>

## 📍 구현 결과 (선택)
![스크린샷 2025-06-02 오전 3 11 38](https://github.com/user-attachments/assets/53aeda6e-4a94-451e-88e7-aec92dceb378)



<br/>

## 📍 기타 사항

프로필 편집 버튼 theme을 button.css에 추가했습니다.

<br/>
