### PR TITLE
[Feat/#188]: 프로필 피드 아이템 삭제

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frolog",
       "version": "1.0.0",
       "dependencies": {
-        "@frolog/frolog-api": "^1.3.1",
+        "@frolog/frolog-api": "^1.4.0-dev",
         "@sentry/nextjs": "^8.35.0",
         "@svgr/webpack": "^8.1.0",
         "@tanstack/react-query": "^5.40.1",
@@ -2552,9 +2552,9 @@
       "dev": true
     },
     "node_modules/@frolog/frolog-api": {
-      "version": "1.3.1",
-      "resolved": "http://dev.frolog.kr/verdaccio/@frolog/frolog-api/-/frolog-api-1.3.1.tgz",
-      "integrity": "sha512-Mvo2LzvhBXtJJKxMSkpl1+Sm6gBqceGI4/3+zW4nThy5z16qe/a5WEsAbzhsSbJxVBm8d6djpyMByV8LPXJOYw==",
+      "version": "1.4.0-dev",
+      "resolved": "http://dev.frolog.kr/verdaccio/@frolog/frolog-api/-/frolog-api-1.4.0-dev.tgz",
+      "integrity": "sha512-uwmlrDPNyADic8zlxdsXBX88y5ZRuuUZtAl1ve3QOxmIlOUqf/g9YL6BbochIayNwhiql46fNrZaNV3qro0OJQ==",
       "dependencies": {
         "ajv": "^8.16.0"
       },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@frolog/frolog-api": "^1.3.1",
+    "@frolog/frolog-api": "^1.4.0-dev",
     "@sentry/nextjs": "^8.35.0",
     "@svgr/webpack": "^8.1.0",
     "@tanstack/react-query": "^5.40.1",

--- a/src/components/Header/ReviewMemoHeader.tsx
+++ b/src/components/Header/ReviewMemoHeader.tsx
@@ -8,6 +8,8 @@ import DeleteWellItem from '@/features/Well/components/DeleteWellItem';
 import TabMenu from '@/components/Tab/TabMenu';
 import { MEMO_REVIEW_TABS } from '@/constants/tabs';
 import HeaderWrapper from '@/components/Wrapper/HeaderWrapper';
+import useNavigateStore from '@/store/navigateStore';
+import DeleteFeedItem from '@/features/Profile/components/Feed/DeleteFeedItem';
 
 interface Props {
   userId: string;
@@ -18,6 +20,8 @@ interface Props {
 
 function ReviewMemoHeader({ userId, wellId, bookId, category }: Props) {
   const rootUserId = useUserId();
+  const navigateState = useNavigateStore((state) => state.navigateState);
+  const isFromProfile = navigateState?.from === 'profile' || false;
 
   useScroll({
     categoryColor: CATEGORY[category].bg,
@@ -30,9 +34,12 @@ function ReviewMemoHeader({ userId, wellId, bookId, category }: Props) {
       <HeaderWrapper isResponsive>
         <div className='flex w-full items-center justify-between'>
           <TabMenu tabs={MEMO_REVIEW_TABS} />
-          {userId === rootUserId && (
-            <DeleteWellItem wellId={wellId} bookId={bookId} />
-          )}
+          {userId === rootUserId &&
+            (isFromProfile ? (
+              <DeleteFeedItem />
+            ) : (
+              <DeleteWellItem wellId={wellId} bookId={bookId} />
+            ))}
         </div>
       </HeaderWrapper>
     </>

--- a/src/data/ui/bottomSheet.tsx
+++ b/src/data/ui/bottomSheet.tsx
@@ -222,4 +222,18 @@ export const sheetData: {
     extraButtonText: '취소',
     description: () => <>포인트가 충분하면 캐릭터가 보여요</>,
   },
+  delete_profile_feed: {
+    getTitle: () => (
+      <>
+        이 책과 관련된 기록을
+        <br /> 전부 삭제할까요?
+      </>
+    ),
+    type: 'error',
+    buttonText: '네, 전부 삭제할게요',
+    extraButtonText: '아니요, 유지할게요',
+    description: () => (
+      <>이 책과 관련된 모든 기록이 우물과 프로필에서 지워져요.</>
+    ),
+  },
 };

--- a/src/features/Join/hooks/useJoin.ts
+++ b/src/features/Join/hooks/useJoin.ts
@@ -84,7 +84,8 @@ export const useJoin = (getValues: () => JoinForm) => {
         STORAGE_KEY.tempAccountKey,
         JSON.stringify({ email: formData.email, password: formData.password })
       );
-      handleLogin(formData.username!);
+      // todo: 회원 가입후 로그인 처리
+      handleLogin('dev test');
     },
   });
 

--- a/src/features/Profile/api/feed.api.ts
+++ b/src/features/Profile/api/feed.api.ts
@@ -1,6 +1,6 @@
 import { baseOptions } from '@/api/options';
 import { DEFAULT_LIMIT } from '@/constants/api';
-import { GetProfileFeed } from '@frolog/frolog-api';
+import { GetProfileFeed, DeleteUserBookContent } from '@frolog/frolog-api';
 import * as Sentry from '@sentry/nextjs';
 
 const getUserProfileFeed = new GetProfileFeed(baseOptions);
@@ -22,5 +22,19 @@ export const getProfileFeed = async (id: string, page: number) => {
       page: 0,
       limit: 6,
     };
+  }
+};
+
+export const deleteProfileFeedItem = async (id: string, isbn: string) => {
+  try {
+    const response = await new DeleteUserBookContent(baseOptions).fetch({
+      id,
+      isbn,
+    });
+
+    return response;
+  } catch (error) {
+    Sentry.captureException(error);
+    return null;
   }
 };

--- a/src/features/Profile/components/Feed/DeleteFeedItem.tsx
+++ b/src/features/Profile/components/Feed/DeleteFeedItem.tsx
@@ -1,0 +1,23 @@
+import { bottomSheet } from '@/modules/BottomSheet';
+import { MoreDotButton } from 'public/icons';
+import React from 'react';
+import { useDeleteProfileFeedItem } from '../../hooks/useDeleteProfileFeedItem';
+
+function DeleteFeedItem() {
+  const { deleteProfileFeedItemMutate } = useDeleteProfileFeedItem();
+  return (
+    <button
+      type='button'
+      onClick={() => {
+        bottomSheet.open({
+          sheetKey: 'delete_profile_feed',
+          onClick: () => deleteProfileFeedItemMutate(),
+        });
+      }}
+    >
+      <MoreDotButton />
+    </button>
+  );
+}
+
+export default DeleteFeedItem;

--- a/src/features/Profile/components/Feed/FeedItemDetail.tsx
+++ b/src/features/Profile/components/Feed/FeedItemDetail.tsx
@@ -16,7 +16,7 @@ function FeedItemDetail({ title, count, category, path }: Props) {
     <button
       type='button'
       className={`flex items-center justify-between bg-category-bg-${category} py-[13px] pl-[12px] pr-[4px] text-category-text-${category}`}
-      onClick={() => navigate(path)}
+      onClick={() => navigate(path, { from: 'profile' })}
     >
       <h3 className='text-body-md-bold'>{title}</h3>
       <div className='flex items-center'>

--- a/src/features/Profile/components/Feed/ProfileFeedItem.tsx
+++ b/src/features/Profile/components/Feed/ProfileFeedItem.tsx
@@ -33,7 +33,11 @@ function ProfileFeedItem({ feedData }: Props) {
         width={191}
         height={272}
         className='flex-[8] cursor-pointer'
-        onClick={() => navigate(getPath.rootUserMemo(userId!, wellId!, isbn))}
+        onClick={() =>
+          navigate(getPath.rootUserMemo(userId!, wellId!, isbn), {
+            from: 'profile',
+          })
+        }
       />
       <div className='flex flex-col gap-[1px]'>
         <FeedItemDetail

--- a/src/features/Profile/hooks/useDeleteProfileFeedItem.ts
+++ b/src/features/Profile/hooks/useDeleteProfileFeedItem.ts
@@ -1,0 +1,28 @@
+import { useMutation } from '@tanstack/react-query';
+import { deleteProfileFeedItem } from '../api/feed.api';
+import { useParams, useRouter } from 'next/navigation';
+import { getPath } from '@/utils/getPath';
+import { useUserId } from '@/store/sessionStore';
+import { toast } from '@/modules/Toast';
+
+export const useDeleteProfileFeedItem = () => {
+  const router = useRouter();
+  const userId = useUserId();
+  const params = useParams();
+  const bookId = params.bookId as string;
+
+  const { mutate: deleteProfileFeedItemMutate } = useMutation({
+    mutationFn: async () => {
+      const res = await deleteProfileFeedItem(userId!, bookId);
+      return res;
+    },
+    onSuccess: () => {
+      router.replace(getPath.profile(userId!));
+    },
+    onError: () => {
+      toast.error('다시 시도해주세요.');
+    },
+  });
+
+  return { deleteProfileFeedItemMutate };
+};

--- a/src/features/Profile/hooks/useDeleteProfileFeedItem.ts
+++ b/src/features/Profile/hooks/useDeleteProfileFeedItem.ts
@@ -1,10 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { deleteProfileFeedItem } from '../api/feed.api';
 import { useParams, useRouter } from 'next/navigation';
 import { getPath } from '@/utils/getPath';
 import { useUserId } from '@/store/sessionStore';
 import { toast } from '@/modules/Toast';
 import { QUERY_KEY } from '@/constants/query';
+import { deleteProfileFeedItem } from '../api/feed.api';
 
 export const useDeleteProfileFeedItem = () => {
   const router = useRouter();

--- a/src/features/Profile/hooks/useDeleteProfileFeedItem.ts
+++ b/src/features/Profile/hooks/useDeleteProfileFeedItem.ts
@@ -1,15 +1,17 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteProfileFeedItem } from '../api/feed.api';
 import { useParams, useRouter } from 'next/navigation';
 import { getPath } from '@/utils/getPath';
 import { useUserId } from '@/store/sessionStore';
 import { toast } from '@/modules/Toast';
+import { QUERY_KEY } from '@/constants/query';
 
 export const useDeleteProfileFeedItem = () => {
   const router = useRouter();
   const userId = useUserId();
   const params = useParams();
   const bookId = params.bookId as string;
+  const queryClient = useQueryClient();
 
   const { mutate: deleteProfileFeedItemMutate } = useMutation({
     mutationFn: async () => {
@@ -18,6 +20,9 @@ export const useDeleteProfileFeedItem = () => {
     },
     onSuccess: () => {
       router.replace(getPath.profile(userId!));
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEY.profileFeed, userId],
+      });
     },
     onError: () => {
       toast.error('다시 시도해주세요.');

--- a/src/hooks/useCustomRouter.ts
+++ b/src/hooks/useCustomRouter.ts
@@ -1,6 +1,7 @@
 import { NAV_ITEM } from '@/constants/nav';
 import { NavItemLabel } from '@/types/nav';
 import { useRouter, useSearchParams } from 'next/navigation';
+import useNavigateStore from '@/store/navigateStore';
 
 /** nav 상태를 붙여주는 커스텀 라우터
  * @param defaultNav - 기본으로 적용될 nav key
@@ -14,6 +15,7 @@ export const useCustomRouter = (
   const searchParams = useSearchParams();
   const currentNav =
     searchParams.get('nav') ?? (defaultNav ? NAV_ITEM[defaultNav].key : '');
+  const setNavigateState = useNavigateStore((state) => state.setNavigateState);
 
   const generatePath = (path: string) => {
     const separator = path.includes('?') ? '&' : '?';
@@ -25,7 +27,10 @@ export const useCustomRouter = (
     }
   };
 
-  const navigate = (path: string) => router.push(generatePath(path));
+  const navigate = (path: string, state?: any) => {
+    router.push(generatePath(path));
+    setNavigateState({ navigateState: state });
+  };
   const replace = (path: string) => router.replace(generatePath(path));
 
   return { navigate, replace, router };

--- a/src/hooks/useCustomRouter.ts
+++ b/src/hooks/useCustomRouter.ts
@@ -29,7 +29,7 @@ export const useCustomRouter = (
 
   const navigate = (path: string, state?: any) => {
     router.push(generatePath(path));
-    setNavigateState({ navigateState: state });
+    setNavigateState(state);
   };
   const replace = (path: string) => router.replace(generatePath(path));
 

--- a/src/store/navigateStore.ts
+++ b/src/store/navigateStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface NavigateStore {
+  navigateState: any;
+  setNavigateState: (state: any) => void;
+}
+
+const useNavigateStore = create<NavigateStore>((set) => ({
+  navigateState: null,
+  setNavigateState: (state) => set({ navigateState: state }),
+}));
+
+export default useNavigateStore;


### PR DESCRIPTION
## 📍 작업 내용

> 프로필 피드 아이템 삭제를 구현했습니다.

- [x] 프로필 피드 아이템 삭제 api 구현
- [x] 프로필 피드 아이템 삭제 구현
- [x] custom router의 navigate 상태 추가
- [x] 우물, 피드아이템 삭제 바텀시트 분기처리

<br/>

## 📍 구현 결과 (선택)

![프로필피드아이템 삭제](https://github.com/user-attachments/assets/dfb2eb58-fcb2-4634-9fb4-094d0e1a1dd1)


<br/>

## 📍 기타 사항

메모, 리뷰 상세 페이지에서 각각 조건에 맞는 바텀시트를 보여주기 위해 지민님이 구현하신 useCustomeRouter의 navigate를
전역 상태를 이용해 상태값도 같이 전달할 수 있게 구현했습니다.
url의 쿼리스트링에 정보를 추가해 처리할까 했지만 상세 페이지 내부에서 탭을 변환할때 url이 초기화 되는 이슈가 있어 전역 상태를 이용했습니다.

추가적으로 피드 아이템 삭제를 구현하면서 우물 아이템 삭제 로직을 참고했는데요,
해당 로직을 참고하면서 메모 상세 페이지 데이터를 가져오는데 staleTime이 0으로 설정된걸 확인했습니다.

20초로 기본 설정되어 있기 때문에 최신화를 위해서 0으로 설정하신거라고 생각이 드는데,
이 로직을 invalidate.Queries를 이용해서 업데이트가 발생한 경우에만 다시 패치하는게 어떨까 생각이 듭니다.

```javascript
import { useUserId } from '@/store/sessionStore';
import { QUERY_KEY } from '@/constants/query';
import { getPath } from '@/utils/getPath';
import { useCustomRouter } from '@/hooks/useCustomRouter';
import { GetMemoRes } from '@frolog/frolog-api';
import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
import { editMemoDetail, getMemoDetail } from '../api/memo.api';

/** 메모 상세 쿼리 및 수정 핸들링 훅 */
export const useMemoDetail = (
  wellId: string,
  bookId: string,
  memoId: string,
  memoData: GetMemoRes
) => {
  const { replace, router } = useCustomRouter('well');
  const userId = useUserId();
  const queryClient = useQueryClient();

  const { data: memoDetail } = useQuery({
    queryKey: [QUERY_KEY.memoDetail, memoId],
    queryFn: () => getMemoDetail({ id: memoId }),
    staleTime: 0,
    initialData: memoData,
  });

  const { mutate: handleEditMemo, isPending } = useMutation({
    mutationFn: (data: MemoFormType) =>
      editMemoDetail({
        id: memoId,
        content: memoDetail?.content === data.memo ? undefined : data.memo,
        is_public:
          memoDetail?.is_public === data.isPublic ? undefined : data.isPublic,
        images: memoDetail?.images === data.images ? undefined : data.images,
      }),
    onSuccess: () => {
      queryClient.invalidateQueries({
        queryKey: [QUERY_KEY.memoDetail, memoId],
      });

      replace(getPath.memoList(userId!, wellId, bookId));
      router.back();
    },
  });

  return { memoDetail, handleEditMemo, isPending };
};
```

invalidate.Queries를 사용할 경우 더 디테일한 조작이 가능하고, 사용자 액션으로 인해 최신화 되는 경우가 아니라면
캐싱된 데이터를 재사용 해도 된다고 생각하고, staleTime:0으로 인해 반복해서 요청되는 불필요한 네트워크 요청을 줄일 수 있다고 생각합니다.
더불어 불필요한 네트워크 요청을 줄이는건 비용 감소에도 효율적이라고 생각합니다.

지민님 의견 부탁드립니다 !
<br/>
