### PR TITLE
[Fix/#152]: 우물 아이템 쿼리 조건 수정

### DIFF
--- a/src/features/Well/components/Well/WellDetail.tsx
+++ b/src/features/Well/components/Well/WellDetail.tsx
@@ -75,7 +75,6 @@ function WellDetail({
       order: newOrder,
     });
 
-    console.log(prevChanges);
     setOrderChanges(prevChanges);
 
     setItems((prevItems) => {

--- a/src/features/Well/components/Well/WellItem/WellItemList.tsx
+++ b/src/features/Well/components/Well/WellItem/WellItemList.tsx
@@ -59,7 +59,7 @@ const WellItemList = React.memo(
     handleMoveItem,
   }: Props) => {
     const { wellItemCount, isLoading: isWellItemCountLoading } =
-      useWellItemCount(userId);
+      useWellItemCount(userId, isRootUser);
     const { baseFrogsCount } = useUserFrogsCount();
 
     const isGotFirstFrog = localStorage.getItem(STORAGE_KEY.gotFirstFrog);

--- a/src/features/Well/hooks/useWellItemCount.ts
+++ b/src/features/Well/hooks/useWellItemCount.ts
@@ -2,11 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import { getUserWellItemsCount } from '../api/well.api';
 import { QUERY_KEY } from '@/constants/query';
 
-export const useWellItemCount = (userId: string) => {
+export const useWellItemCount = (userId: string, isRootUser: boolean) => {
   const { data, isLoading } = useQuery({
     queryKey: [QUERY_KEY.wellItemCount, userId],
     queryFn: () => getUserWellItemsCount(userId),
-    enabled: !!userId,
+    enabled: !!userId && isRootUser,
   });
 
   return {


### PR DESCRIPTION
## 📍 작업 내용
> 우물 아이템 쿼리 조건 수정

우물 아이템 개수 조회 쿼리의 조건을 수정했습니다.

- 기존: userId가 있는 경우 조회
- 개선: userId가 있고, 해당 우물이 본인 우물인 경우 조회

<br/>
